### PR TITLE
Adjust PID coeffector to serve turning better

### DIFF
--- a/firmware-sensact/source/differential_drive_system.cpp
+++ b/firmware-sensact/source/differential_drive_system.cpp
@@ -319,7 +319,7 @@ CDifferentialDriveSystem::CPIDControlStepInterrupt::CPIDControlStepInterrupt(
    //m_fKi(0.00f),
    //m_fKd(0.35f) {
    /* arena */
-   m_fKp(1.00f),
+   m_fKp(1.20f),
    m_fKi(0.00f),
    m_fKd(0.25f) {
    Register(this, un_intr_vect_num);


### PR DESCRIPTION
The second robot shows difficulty when turning on the lab ground.
Enlarge P of PID slightly to make the builderbot more powerful to turn smoothly.